### PR TITLE
Able to change MaxPlayers value druing a game

### DIFF
--- a/lobby.go
+++ b/lobby.go
@@ -197,7 +197,7 @@ func wsListen(lobby *Lobby, player *Player, socket *websocket.Conn) {
 								newMaxPlayersValue := strings.TrimSpace(command[1])
 								newMaxPlayersValueInt, err := strconv.ParseInt(newMaxPlayersValue, 10, 64)
 								if err == nil {
-									if int(newMaxPlayersValueInt) > len(lobby.Players) && newMaxPlayersValueInt <= lobbySettingBounds.MaxMaxPlayers && newMaxPlayersValueInt >= lobbySettingBounds.MinMaxPlayers {
+									if int(newMaxPlayersValueInt) >= len(lobby.Players) && newMaxPlayersValueInt <= lobbySettingBounds.MaxMaxPlayers && newMaxPlayersValueInt >= lobbySettingBounds.MinMaxPlayers {
 										lobby.MaxPlayers = int(newMaxPlayersValueInt)
 
 										maxPlayerChangeEvent := &JSEvent{Type: "message", Data: Message{
@@ -233,7 +233,7 @@ func wsListen(lobby *Lobby, player *Player, socket *websocket.Conn) {
 							} else {
 								player.ws.WriteJSON(JSEvent{Type: "message", Data: Message{
 									Author:  "System",
-									Content: fmt.Sprintf("Only lobby owner can change MaxPlayers value."),
+									Content: fmt.Sprintf("Only the lobby owner can change MaxPlayers setting."),
 								}})
 							}
 						case "help":

--- a/lobby.go
+++ b/lobby.go
@@ -665,6 +665,7 @@ func CreateLobby(w http.ResponseWriter, r *http.Request) {
 
 		//FIXME Make a dedicated method that uses a mutex?
 		lobby.Players = append(lobby.Players, player)
+		lobby.Owner = player
 
 		// Use the players generated usersession and pass it as a cookie.
 		http.SetCookie(w, &http.Cookie{

--- a/lobby_logic.go
+++ b/lobby_logic.go
@@ -63,6 +63,8 @@ type Lobby struct {
 
 	// Drawer references the Player that is currently drawing.
 	Drawer *Player
+	// Owner references the Player that created the lobby.
+	Owner *Player
 	// CurrentWord represents the word that was last selected. If no word has
 	// been selected yet or the round is already over, this should be empty.
 	CurrentWord string


### PR DESCRIPTION
Now the lobby owner can use `!setmp number` to change MaxPlayers value during a game
Can't be lower than `current-player-count/MinMaxPlayer` or higher than `MaxMaxPlayers` which is set to 24 (hardcoded in source code)