### PR TITLE
Making votekick an option in the lobby setup page

### DIFF
--- a/lobby.go
+++ b/lobby.go
@@ -760,6 +760,7 @@ type LobbyPageData struct {
 	WordHints []*WordHint
 	Round     int
 	Rounds    int
+	EnableVotekick bool
 }
 
 func getLobby(w http.ResponseWriter, r *http.Request) *Lobby {
@@ -782,7 +783,7 @@ func getLobby(w http.ResponseWriter, r *http.Request) *Lobby {
 func GetPlayers(w http.ResponseWriter, r *http.Request) {
 	lobby := getLobby(w, r)
 	if lobby != nil {
-		templatingError := lobbyPage.ExecuteTemplate(w, "players", lobby.Players)
+		templatingError := lobbyPage.ExecuteTemplate(w, "players", lobby)
 		if templatingError != nil {
 			errorPage.ExecuteTemplate(w, "error.html", templatingError.Error())
 		}
@@ -997,6 +998,7 @@ func ShowLobby(w http.ResponseWriter, r *http.Request) {
 				LobbyID: lobby.ID,
 				Round:   lobby.Round,
 				Rounds:  lobby.Rounds,
+				EnableVotekick: lobby.EnableVotekick,
 			}
 
 			for _, player := range lobby.Players {
@@ -1021,6 +1023,7 @@ func ShowLobby(w http.ResponseWriter, r *http.Request) {
 				LobbyID: lobby.ID,
 				Round:   lobby.Round,
 				Rounds:  lobby.Rounds,
+				EnableVotekick: lobby.EnableVotekick,
 			}
 
 			lobbyPage.ExecuteTemplate(w, "lobby.html", pageData)

--- a/lobby.html
+++ b/lobby.html
@@ -38,7 +38,7 @@
         <span id="time-left">Time Left: ∞</span>
 
         <div id="player-container">
-            {{template "players" .Players}}
+            {{template "players" .}}
         </div>
 
         <div id="drawing-board-wrapper">

--- a/lobby_create.html
+++ b/lobby_create.html
@@ -49,6 +49,8 @@
                     <b>Clients per IP Limit</b>
                     <input class="input-item" type="number" name="clients_per_ip_limit" min="{{.MinClientsPerIPLimit}}"
                         max="{{.MaxClientsPerIPLimit}}" value="{{.ClientsPerIPLimit}}" />
+                   <b>Enable Votekick</b>
+                    <input class="input-item" type="checkbox" name="enable_votekick" value="{{.EnableVotekick}}" />
                     <button type="submit" form="lobby-create" style="grid-column-start: 1; grid-column-end: 3;">Open
                         Lobby</button>
                 </form>

--- a/lobby_create.html
+++ b/lobby_create.html
@@ -50,7 +50,7 @@
                     <input class="input-item" type="number" name="clients_per_ip_limit" min="{{.MinClientsPerIPLimit}}"
                         max="{{.MaxClientsPerIPLimit}}" value="{{.ClientsPerIPLimit}}" />
                    <b>Enable Votekick</b>
-                    <input class="input-item" type="checkbox" name="enable_votekick" value="{{.EnableVotekick}}" />
+                    <input class="input-item" type="checkbox" name="enable_votekick" value="true" checked="{{.EnableVotekick}}" />
                     <button type="submit" form="lobby-create" style="grid-column-start: 1; grid-column-end: 3;">Open
                         Lobby</button>
                 </form>

--- a/lobby_logic.go
+++ b/lobby_logic.go
@@ -98,6 +98,7 @@ type Lobby struct {
 	CustomWordsChance     int
 	clientsPerIPLimit     int
 	currentDrawing        []*Pixel
+	EnableVotekick bool
 }
 
 // Pixel is the struct that a client send when drawing
@@ -162,7 +163,8 @@ func createLobby(
 	maxPlayers int,
 	customWords []string,
 	customWordsChance int,
-	clientsPerIPLimit int) *Lobby {
+	clientsPerIPLimit int,
+	enableVotekick bool) *Lobby {
 
 	createDeleteMutex.Lock()
 
@@ -176,6 +178,7 @@ func createLobby(
 		CustomWordsChance:   customWordsChance,
 		timeLeftTickerReset: make(chan struct{}),
 		clientsPerIPLimit:   clientsPerIPLimit,
+		EnableVotekick: enableVotekick,
 		currentDrawing:      []*Pixel{},
 	}
 

--- a/lobby_players.html
+++ b/lobby_players.html
@@ -1,10 +1,13 @@
 {{define "players"}}
-    {{range .}}
+    {{$kickable := .EnableVotekick}}
+    {{range .Players}}
     <div class="player {{if eq .State 2}}player-done{{else if eq .State 3}}player-disconnected{{end}}">
         <span class="rank">{{.Rank}}</span>
         <div class="name-and-buttons">
             <span class="playername">{{.Name}}</span>
-            <button class="kick-button" id="kick-button" type="button" title="Vote to kick this player" alt="Vote to kick this player" onclick="onClickKickButton({{.ID}})">👋</button>
+            {{if $kickable}}
+              <button class="kick-button" id="kick-button" type="button" title="Vote to kick this player" alt="Vote to kick this player" onclick="onClickKickButton({{.ID}})">👋</button>
+            {{end}}
         </div>
         <div class="score-and-status">
             <div>


### PR DESCRIPTION
Hey there,

I tried implementing an option to disable Votekicking. I realized that the incentive to kick the other player if you are only two players is too high ;)

**This pull request adds a checkbox "Enable Votekicking" in the lobby creation form. If players try to kick a player although it was disabled in the settings, the kick request is discarded.**

I think, we should also hide the votekick button if votekicking is disabled. I tried to do that with
```

            {{if .EnableVotekick}}
              <button class="kick-button" id="kick-button" type="button" title="Vote to kick this player" alt="Vote to kick this player" onclick="onClickKickButton({{.ID}})">👋</button>
            {{end}}
```

in lobby_players.html, but that broke the lobby. Any help regarding this is appreciated.

I hope I can contribute to this project with this small pull request :)