### PR TITLE
Change votekick icon from 👋 to 🥾

### DIFF
--- a/lobby_players.html
+++ b/lobby_players.html
@@ -6,7 +6,7 @@
         <div class="name-and-buttons">
             <span class="playername">{{.Name}}</span>
             {{if $kickable}}
-              <button class="kick-button" id="kick-button" type="button" title="Vote to kick this player" alt="Vote to kick this player" onclick="onClickKickButton({{.ID}})">👋</button>
+              <button class="kick-button" id="kick-button" type="button" title="Vote to kick this player" alt="Vote to kick this player" onclick="onClickKickButton({{.ID}})">🥾</button>
             {{end}}
         </div>
         <div class="score-and-status">


### PR DESCRIPTION
When testing with other players, they largely seemed to not notice the button
for kicking people, even when actively searching for it. This is probably also
due to the color of the hand blending in with the background.