### PR TITLE
Remove unnecessary bounds on lobby creation

### DIFF
--- a/lobby_create.html
+++ b/lobby_create.html
@@ -29,30 +29,26 @@
 
                 {{end}}
                 <form id="lobby-create" class="input-container" action="/lobby/create" method="POST">
-                    <b>Lobby-Password</b>
-                    <input class="input-item" name="lobby_password" placeholder="Enter your password or leave empty"
+                    <label for="lobby_password">Lobby Password</label>
+                    <input name="lobby_password" placeholder="Enter your password or leave empty"
                         type="password" value="{{.Password}}" />
-                    <b>Drawing Time</b>
-                    <input class="input-item" type="number" name="drawing_time" min="{{.MinDrawingTime}}"
-                        max="{{.MaxDrawingTime}}" value="{{.DrawingTime}}" />
-                    <b>Rounds</b>
-                    <input class="input-item" type="number" name="rounds" min="{{.MinRounds}}" max="{{.MaxRounds}}"
-                        value="{{.Rounds}}" />
-                    <b>Maximum Players</b>
-                    <input class="input-item" type="number" name="max_players" min="{{.MinMaxPlayers}}"
-                        max="{{.MaxMaxPlayers}}" value="{{.MaxPlayers}}" />
-                    <b>Custom Words</b>
-                    <textarea class="input-item" name="custom_words"
+                    <label for="drawing_time">Drawing Time</label>
+                    <input type="number" name="drawing_time" min=1 step=1 value="{{.DrawingTime}}" required />
+                    <label for="rounds">Rounds</label>
+                    <input type="number" name="rounds" min=1 step=1 value="{{.Rounds}}" required />
+                    <label for="max_players">Maximum Players</label>
+                    <input type="number" name="max_players" min=2 step=1 value="{{.MaxPlayers}}" required />
+                    <label for="custom_words">Custom Words</label>
+                    <textarea name="custom_words"
                         placeholder="Enter your additional words, seperating them by commas">{{.CustomWords}}</textarea>
-                    <b>Custom Words Chance</b>
-                    <input type="range" name="custom_words_chance" min="1" max="100" value="{{.CustomWordsChance}}">
-                    <b>Clients per IP Limit</b>
-                    <input class="input-item" type="number" name="clients_per_ip_limit" min="{{.MinClientsPerIPLimit}}"
-                        max="{{.MaxClientsPerIPLimit}}" value="{{.ClientsPerIPLimit}}" />
-                   <b>Enable Votekick</b>
-                    <input class="input-item" type="checkbox" name="enable_votekick" value="true" checked="{{.EnableVotekick}}" />
-                    <button type="submit" form="lobby-create" style="grid-column-start: 1; grid-column-end: 3;">Open
-                        Lobby</button>
+                    <label for="custom_words_chance">Custom Words Chance</label>
+                    <input type="range" name="custom_words_chance" min=1 max=100 value="{{.CustomWordsChance}}" />
+                    <label for="clients_per_ip_limit">Clients per IP Limit</label>
+                    <input type="number" name="clients_per_ip_limit" min=1 step=1
+                            value="{{.ClientsPerIPLimit}}" required />
+                    <label for="enable_votekick">Enable Votekick</label>
+                    <input type="checkbox" name="enable_votekick" value=true {{if .EnableVotekick}} checked {{end}} />
+                    <button type="submit" form="lobby-create" style="grid-column-start: 1; grid-column-end: 3;">Open Lobby</button>
                 </form>
             </div>
         </div>

--- a/lobby_test.go
+++ b/lobby_test.go
@@ -67,10 +67,6 @@ func Test_parseDrawingTime(t *testing.T) {
 	}{
 		{"empty value", "", 0, true},
 		{"space", " ", 0, true},
-		{"less than minimum", "59", 0, true},
-		{"more than maximum", "301", 0, true},
-		{"maximum", "300", 300, false},
-		{"minimum", "60", 60, false},
 		{"something valid", "150", 150, false},
 	}
 	for _, tt := range tests {
@@ -96,10 +92,6 @@ func Test_parseRounds(t *testing.T) {
 	}{
 		{"empty value", "", 0, true},
 		{"space", " ", 0, true},
-		{"less than minimum", "0", 0, true},
-		{"more than maximum", "21", 0, true},
-		{"maximum", "20", 20, false},
-		{"minimum", "1", 1, false},
 		{"something valid", "15", 15, false},
 	}
 	for _, tt := range tests {
@@ -125,10 +117,6 @@ func Test_parseMaxPlayers(t *testing.T) {
 	}{
 		{"empty value", "", 0, true},
 		{"space", " ", 0, true},
-		{"less than minimum", "1", 0, true},
-		{"more than maximum", "25", 0, true},
-		{"maximum", "24", 24, false},
-		{"minimum", "2", 2, false},
 		{"something valid", "15", 15, false},
 	}
 	for _, tt := range tests {

--- a/resources/style.css
+++ b/resources/style.css
@@ -95,7 +95,7 @@ footer {
     grid-row-gap: 10px;
 }
 
-.input-item {
+.input-container input {
     width: inherit;
     min-width: 300px;
 }


### PR DESCRIPTION
In addition, the input form is fixed and properly makes use of the
in-built validation in browsers.

The bounds were unnecessary and served no real purpose. Users can still
select what they selected before this patch, but also things that were
arbitrarily disallowed. As for the server, having 10000 players in a single
lobby is surely extreme, but shouldn't be much worse than having 10000 players
in separate sessions. The network load for drawing should be O(n),
and the network load for messages is O(n^2), but considering that it's just
text, and each user sends maybe 4 characters per second, even with 10k players
it's only ca. 381 MiB/s worth of messages sent to users.