### PR TITLE
Allow selecting your own words at the selection screen

### DIFF
--- a/lobby.go
+++ b/lobby.go
@@ -59,6 +59,7 @@ type CreatePageData struct {
 	MaxPlayers        string
 	CustomWords       string
 	CustomWordsChance string
+	AllowCustomWords  bool
 	ClientsPerIPLimit string
 	EnableVotekick    bool
 }
@@ -70,6 +71,7 @@ func createDefaultLobbyCreatePageData() *CreatePageData {
 		Rounds:            "4",
 		MaxPlayers:        "12",
 		CustomWordsChance: "50",
+		AllowCustomWords:  false,
 		ClientsPerIPLimit: "1",
 		EnableVotekick:    true,
 	}
@@ -287,6 +289,18 @@ func wsListen(lobby *Lobby, player *Player, socket *websocket.Conn) {
 					lobby.CurrentWord = lobby.WordChoice[chosenIndex]
 					lobby.WordChoice = nil
 					lobby.WordHints = createWordHintFor(lobby.CurrentWord)
+					lobby.WordHintsShown = showAllInWordHints(lobby.WordHints)
+					triggerWordHintUpdate(lobby)
+					if lobby.Drawer.State != Disconnected && lobby.Drawer.ws != nil {
+						lobby.Drawer.WriteAsJSON(JSEvent{Type: "your-turn"})
+					}
+				}
+			} else if received.Type == "choose-word-custom" {
+				word := (received.Data).(string)
+				if player == lobby.Drawer {
+					lobby.CurrentWord = word
+					lobby.WordChoice = nil
+					lobby.WordHints = createWordHintFor(word)
 					lobby.WordHintsShown = showAllInWordHints(lobby.WordHints)
 					triggerWordHintUpdate(lobby)
 					if lobby.Drawer.State != Disconnected && lobby.Drawer.ws != nil {
@@ -783,13 +797,14 @@ func triggerSimpleUpdateEvent(eventType string, lobby *Lobby) {
 // LobbyPageData is the data necessary for initially displaying all data of
 // the lobbies webpage.
 type LobbyPageData struct {
-	Players        []*Player
-	Port           int
-	LobbyID        string
-	WordHints      []*WordHint
-	Round          int
-	Rounds         int
-	EnableVotekick bool
+	Players          []*Player
+	Port             int
+	LobbyID          string
+	WordHints        []*WordHint
+	Round            int
+	Rounds           int
+	EnableVotekick   bool
+	AllowCustomWords bool
 }
 
 func getLobby(w http.ResponseWriter, r *http.Request) *Lobby {
@@ -871,6 +886,7 @@ func CreateLobby(w http.ResponseWriter, r *http.Request) {
 	maxPlayers, maxPlayersInvalid := parseMaxPlayers(r.Form.Get("max_players"))
 	customWords, customWordsInvalid := parseCustomWords(r.Form.Get("custom_words"))
 	customWordChance, customWordChanceInvalid := parseCustomWordsChance(r.Form.Get("custom_words_chance"))
+	allowCustomWords := r.Form.Get("allow_custom_words") == "true"
 	clientsPerIPLimit, clientsPerIPLimitInvalid := parseClientsPerIPLimit(r.Form.Get("clients_per_ip_limit"))
 	enableVotekick := r.Form.Get("enable_votekick") == "true"
 
@@ -883,6 +899,7 @@ func CreateLobby(w http.ResponseWriter, r *http.Request) {
 		MaxPlayers:        r.Form.Get("max_players"),
 		CustomWords:       r.Form.Get("custom_words"),
 		CustomWordsChance: r.Form.Get("custom_words_chance"),
+		AllowCustomWords:  r.Form.Get("allow_custom_words") == "true",
 		ClientsPerIPLimit: r.Form.Get("clients_per_ip_limit"),
 		EnableVotekick:    r.Form.Get("enable_votekick") == "true",
 	}
@@ -915,7 +932,7 @@ func CreateLobby(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	} else {
-		lobby := createLobby(password, drawingTime, rounds, maxPlayers, customWords, customWordChance, clientsPerIPLimit, enableVotekick)
+		lobby := createLobby(password, drawingTime, rounds, maxPlayers, customWords, customWordChance, allowCustomWords, clientsPerIPLimit, enableVotekick)
 		var playerName string
 		usernameCookie, noCookieError := r.Cookie("username")
 		if noCookieError == nil {
@@ -1022,12 +1039,13 @@ func ShowLobby(w http.ResponseWriter, r *http.Request) {
 			recalculateRanks(lobby)
 
 			pageData := &LobbyPageData{
-				Port:           *portHTTP,
-				Players:        lobby.Players,
-				LobbyID:        lobby.ID,
-				Round:          lobby.Round,
-				Rounds:         lobby.Rounds,
-				EnableVotekick: lobby.EnableVotekick,
+				Port:             *portHTTP,
+				Players:          lobby.Players,
+				LobbyID:          lobby.ID,
+				Round:            lobby.Round,
+				Rounds:           lobby.Rounds,
+				EnableVotekick:   lobby.EnableVotekick,
+				AllowCustomWords: lobby.AllowCustomWords,
 			}
 
 			for _, player := range lobby.Players {
@@ -1053,6 +1071,7 @@ func ShowLobby(w http.ResponseWriter, r *http.Request) {
 				Round:          lobby.Round,
 				Rounds:         lobby.Rounds,
 				EnableVotekick: lobby.EnableVotekick,
+				AllowCustomWords: lobby.AllowCustomWords,
 			}
 
 			lobbyPage.ExecuteTemplate(w, "lobby.html", pageData)

--- a/lobby.html
+++ b/lobby.html
@@ -21,6 +21,14 @@
         <button id="word-button-one" class="word-button" onclick="chooseWord(1)">Placeholder</button>
         <button id="word-button-two" class="word-button" onclick="chooseWord(2)">Placeholder</button>
     </div>
+    {{if .AllowCustomWords}}
+        <div class="word-button-container">
+            <form onsubmit="event.preventDefault(); chooseWordCustom(this)">
+                <input name="word" type="text" placeholder="Custom word" required>
+                <button class="word-button" type="submit">Use custom word</button>
+            </form>
+        </div>
+    {{end}}
 </div>
 <div class="content-wrapper">
     <div id="lobby">
@@ -333,6 +341,15 @@
         socket.send(JSON.stringify({
             Type: "choose-word",
             Data: index
+        }));
+        wordDialog.style.visibility = "hidden";
+    }
+
+    function chooseWordCustom(form) {
+        let word = form.elements.word.value;
+        socket.send(JSON.stringify({
+            Type: "choose-word-custom",
+            Data: word
         }));
         wordDialog.style.visibility = "hidden";
     }

--- a/lobby_create.html
+++ b/lobby_create.html
@@ -46,6 +46,8 @@
                         placeholder="Enter your additional words, seperating them by commas">{{.CustomWords}}</textarea>
                     <b>Custom Words Chance</b>
                     <input type="range" name="custom_words_chance" min="1" max="100" value="{{.CustomWordsChance}}">
+                    <label for="allow_custom_words">Allow arbitrary words to be chosen by all players</label>
+                    <input type="checkbox" name="allow_custom_words" value=true {{if .AllowCustomWords}} checked {{end}} />
                     <b>Clients per IP Limit</b>
                     <input class="input-item" type="number" name="clients_per_ip_limit" min="{{.MinClientsPerIPLimit}}"
                         max="{{.MaxClientsPerIPLimit}}" value="{{.ClientsPerIPLimit}}" />

--- a/lobby_logic.go
+++ b/lobby_logic.go
@@ -96,6 +96,7 @@ type Lobby struct {
 	scoreEarnedByGuessers int
 	alreadyUsedWords      []string
 	CustomWordsChance     int
+	AllowCustomWords      bool
 	clientsPerIPLimit     int
 	currentDrawing        []*Pixel
 	EnableVotekick        bool
@@ -164,6 +165,7 @@ func createLobby(
 	maxPlayers int,
 	customWords []string,
 	customWordsChance int,
+	allowCustomWords bool,
 	clientsPerIPLimit int,
 	enableVotekick bool) *Lobby {
 
@@ -177,6 +179,7 @@ func createLobby(
 		MaxPlayers:          maxPlayers,
 		CustomWords:         customWords,
 		CustomWordsChance:   customWordsChance,
+		AllowCustomWords:    allowCustomWords,
 		timeLeftTickerReset: make(chan struct{}),
 		clientsPerIPLimit:   clientsPerIPLimit,
 		EnableVotekick:      enableVotekick,

--- a/resources/lobby.css
+++ b/resources/lobby.css
@@ -113,11 +113,16 @@ body {
     left: 50%;
     top: 50%;
     width: auto;
-    height: 150px;
     transform: translate(-50%, -50%);
     align-items: center;
     justify-content: center;
     visibility: hidden;
+    padding: 1%;
+    border-radius: 1rem;
+}
+
+#word-dialog > * {
+    margin: 1rem;
 }
 
 .word-dialog-text {


### PR DESCRIPTION
This feature needs to be enabled manually at the lobby
creation menu.
You still get 3 words in the same way before (for inspiration),
but you in addition have an extra text input field and a button
for submitting it that allows you to select a custom string.