### PR TITLE
Workaround for capital sharp s

### DIFF
--- a/resources/frontend/lobby.css
+++ b/resources/frontend/lobby.css
@@ -17,7 +17,8 @@
 }
 
 .guess-letter {
-    font-family: monospace;
+    display: inline-block;
+    width: 1.5rem;
     font-weight: bold;
     font-size: 1.5rem;
 }

--- a/templates/lobby.html
+++ b/templates/lobby.html
@@ -613,6 +613,8 @@
                 wordContainer.innerHTML += '<span class="guess-letter guess-letter-underline">&nbsp;</span>';
             } else {
                 let char = String.fromCharCode(hint.character);
+                if(char == "ß")
+                    char = "ẞ";
                 if (hint.underline) {
                     wordContainer.innerHTML += '<span class="guess-letter guess-letter-underline">' + char + '</span>'
                 } else {


### PR DESCRIPTION
Fixes #126 

This lead to ẞ looking strange in the monospace font, so changed the word font to Montserrat and set the spans to a fixed width. Maybe you want to handle this differently.