### PR TITLE
Fix weird behaviour of centered dialogs

### DIFF
--- a/resources/frontend/lobby.css
+++ b/resources/frontend/lobby.css
@@ -140,7 +140,7 @@
 
 .dialog-title {
     margin-bottom: 1rem;
-    font-size: 2rem;
+    font-size: 3rem;
     font-weight: bold;
     color: rgb(240, 105, 127);
 }

--- a/resources/frontend/lobby.css
+++ b/resources/frontend/lobby.css
@@ -65,13 +65,22 @@
     height: 100%;
 }
 
-#center-dialog-container {
+#center-dialogs {
     pointer-events: none;
     touch-action: none;
     position: absolute;
     width: 100%;
     height: 100%;
     z-index: 20;
+}
+
+#center-dialog-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    width: 100%;
+    height: 100%;
 }
 
 .center-dialog {

--- a/resources/frontend/lobby.css
+++ b/resources/frontend/lobby.css
@@ -84,10 +84,6 @@
     align-items: center;
     visibility: hidden;
     padding: 1rem;
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
     /* A dialog should never fully hide the canvas. */
     max-width: 80%;
     max-height: 80%;

--- a/templates/lobby.html
+++ b/templates/lobby.html
@@ -54,53 +54,65 @@
                 "center-dialog" is the window content. Depending on which dialog
                 we want to show, we show a different content. Technically there could be more
                 than one dialog visible at a time, but they'll be layered. -->
-                <div id="center-dialog-container">
-                    <div id="word-dialog" class="center-dialog">
-                        <span class="dialog-title">Choose a word</span>
-                        <div class="center-dialog-content">
-                            <div class="word-button-container">
-                                <button id="word-button-zero" class="dialog-button" onclick="chooseWord(0)">Placeholder
-                                </button>
-                                <button id="word-button-one" class="dialog-button" onclick="chooseWord(1)">Placeholder
-                                </button>
-                                <button id="word-button-two" class="dialog-button" onclick="chooseWord(2)">Placeholder
-                                </button>
+                <div id="center-dialogs">
+                    <div id="center-dialog-container">
+                        <div id="word-dialog" class="center-dialog">
+                            <span class="dialog-title">Choose a word</span>
+                            <div class="center-dialog-content">
+                                <div class="word-button-container">
+                                    <button id="word-button-zero" class="dialog-button" onclick="chooseWord(0)">Placeholder
+                                    </button>
+                                    <button id="word-button-one" class="dialog-button" onclick="chooseWord(1)">Placeholder
+                                    </button>
+                                    <button id="word-button-two" class="dialog-button" onclick="chooseWord(2)">Placeholder
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>
 
-                    <div id="start-dialog" class="center-dialog">
-                        <span class="dialog-title">Start the game</span>
-                        <div class="center-dialog-content">
-                            <button class="dialog-button" onclick="startGame()">Start</button>
+                    <div id="center-dialog-container">
+                        <div id="start-dialog" class="center-dialog">
+                            <span class="dialog-title">Start the game</span>
+                            <div class="center-dialog-content">
+                                <button class="dialog-button" onclick="startGame()">Start</button>
+                            </div>
                         </div>
                     </div>
 
-                    <div id="game-over-dialog" class="center-dialog">
-                        <span class="dialog-title">Game over!</span>
-                        <div class="center-dialog-content">
-                            Please wait for your lobby host to restart the game.
+                    <div id="center-dialog-container">
+                        <div id="game-over-dialog" class="center-dialog">
+                            <span class="dialog-title">Game over!</span>
+                            <div class="center-dialog-content">
+                                Please wait for your lobby host to restart the game.
+                            </div>
                         </div>
                     </div>
 
-                    <div id="restart-dialog" class="center-dialog">
-                        <span class="dialog-title">Game over!</span>
-                        <div class="center-dialog-content">
-                            <button class="dialog-button" onclick="startGame()">Restart</button>
+                    <div id="center-dialog-container">
+                        <div id="restart-dialog" class="center-dialog">
+                            <span class="dialog-title">Game over!</span>
+                            <div class="center-dialog-content">
+                                <button class="dialog-button" onclick="startGame()">Restart</button>
+                            </div>
                         </div>
                     </div>
 
-                    <div id="unstarted-dialog" class="center-dialog">
-                        <span class="dialog-title">Game hasn't started</span>
-                        <div class="center-dialog-content">
-                            Please wait for your lobby host to start the game.
+                    <div id="center-dialog-container">
+                        <div id="unstarted-dialog" class="center-dialog">
+                            <span class="dialog-title">Game hasn't started</span>
+                            <div class="center-dialog-content">
+                                Please wait for your lobby host to start the game.
+                            </div>
                         </div>
                     </div>
 
-                    <div id="kick-dialog" class="center-dialog">
-                        <span class="dialog-title">Vote to kick a player</span>
-                        <div id="kick-dialog-players"></div>
-                        <button onclick="hideKickDialog()" class="dialog-button dialog-close-button">Close</button>
+                    <div id="center-dialog-container">
+                        <div id="kick-dialog" class="center-dialog">
+                            <span class="dialog-title">Vote to kick a player</span>
+                            <div id="kick-dialog-players"></div>
+                            <button onclick="hideKickDialog()" class="dialog-button dialog-close-button">Close</button>
+                        </div>
                     </div>
                 </div>
                 <div id="toolbox">


### PR DESCRIPTION
`max-width 80%` was pretty much useless since dialog was being moved to right and bottom by 50%, and getting transformed to 50% of 50% top and same for left.

Instead of centralizing it like this, I've just created a simple container that contains only one dialog in it, which has width and height of 100%, `display flex`, and centered elements in them, so this way you don't even need position absolute of  the dialogs themselves or setting their positions directly then transforming them to put them in center

Those said containers are all wrapped into another container, which holds basically a group of dialog containers

An example of tree of the dialog views:
- a container holding a group of containers
  - dialog container
    -dialog
  - dialog container
    -dialog
  - dialog container
    -dialog
  - dialog container
    -dialog

