### PR TITLE
Fixed incorrect member being used to specify author ID

### DIFF
--- a/game/lobby.go
+++ b/game/lobby.go
@@ -257,7 +257,7 @@ func sendMessageToAll(message string, sender *Player, lobby *Lobby) {
 	for _, target := range lobby.players {
 		WriteAsJSON(target, JSEvent{Type: "message", Data: Message{
 			Author:   html.EscapeString(sender.Name),
-			AuthorID: sender.Name,
+			AuthorID: sender.ID,
 			Content:  escaped,
 		}})
 	}


### PR DESCRIPTION
This is most likely my smallest pull request I've ever done so far.

It just uses `sender.ID` instead of `sender.Name` to specify message author ID.