### PR TITLE
Score calculation improvements

### DIFF
--- a/communication/http.go
+++ b/communication/http.go
@@ -15,6 +15,11 @@ func userFacingError(w http.ResponseWriter, errorMessage string) {
 	}
 }
 
+// remoteAddressToSimpleIP removes unnecessary clutter from the input,
+// reducing it to a simple IPv4. We expect two different formats here.
+// One being http.Request#RemoteAddr (127.0.0.1:12345) and the other
+// being forward headers, which contain brackets, as there's no proper
+// API, but just a string that needs to be parsed.
 func remoteAddressToSimpleIP(input string) string {
 	address := input
 	lastIndexOfDoubleColon := strings.LastIndex(address, ":")
@@ -25,6 +30,8 @@ func remoteAddressToSimpleIP(input string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(address, "["), "]")
 }
 
+// Serve will start an HTTP server listening on the given port.
+// This is a blocking call-
 func Serve(port int) error {
 	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 }

--- a/communication/v1.go
+++ b/communication/v1.go
@@ -31,7 +31,7 @@ func publicLobbies(w http.ResponseWriter, r *http.Request) {
 	for _, lobby := range lobbies {
 		lobbyEntries = append(lobbyEntries, &LobbyEntry{
 			ID:              lobby.ID,
-			PlayerCount:     len(lobby.GetPlayers()),
+			PlayerCount:     lobby.GetOccupiedPlayerSlots(),
 			MaxPlayers:      lobby.MaxPlayers,
 			Round:           lobby.Round,
 			MaxRounds:       lobby.MaxRounds,

--- a/game/data_test.go
+++ b/game/data_test.go
@@ -1,0 +1,47 @@
+package game
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOccupiedPlayerCount(t *testing.T) {
+	lobby := &Lobby{}
+	if lobby.GetOccupiedPlayerSlots() != 0 {
+		t.Errorf("Occupied player count expected to be 0, but was %d", lobby.GetOccupiedPlayerSlots())
+	}
+
+	//While disconnect, there's no disconnect time, which we count as occupied.
+	lobby.players = append(lobby.players, &Player{})
+	if lobby.GetOccupiedPlayerSlots() != 1 {
+		t.Errorf("Occupied player count expected to be 1, but was %d", lobby.GetOccupiedPlayerSlots())
+	}
+
+	lobby.players = append(lobby.players, &Player{
+		Connected: true,
+	})
+	if lobby.GetOccupiedPlayerSlots() != 2 {
+		t.Errorf("Occupied player count expected to be 2, but was %d", lobby.GetOccupiedPlayerSlots())
+	}
+
+	disconnectedPlayer := &Player{
+		Connected: false,
+	}
+	lobby.players = append(lobby.players, disconnectedPlayer)
+	if lobby.GetOccupiedPlayerSlots() != 3 {
+		t.Errorf("Occupied player count expected to be 3, but was %d", lobby.GetOccupiedPlayerSlots())
+	}
+
+	now := time.Now()
+	disconnectedPlayer.disconnectTime = &now
+	if lobby.GetOccupiedPlayerSlots() != 3 {
+		t.Errorf("Occupied player count expected to be 3, but was %d", lobby.GetOccupiedPlayerSlots())
+	}
+
+	past := time.Now().Local().AddDate(-1, 0, 0)
+	disconnectedPlayer.disconnectTime = &past
+	if lobby.GetOccupiedPlayerSlots() != 2 {
+		t.Errorf("Occupied player count expected to be 2, but was %d", lobby.GetOccupiedPlayerSlots())
+	}
+
+}

--- a/game/lobby.go
+++ b/game/lobby.go
@@ -240,7 +240,7 @@ func handleMessage(input string, sender *Player, lobby *Lobby) {
 			//The forumla here represents an exponential decline based on the time taken.
 			//This way fast players get more points, however not a lot more.
 			//The bonus gained by guessing before hints are shown is therefore still somewhat relevant.
-			declineFactor := math.Ceil(1.0 / float64(lobby.DrawingTime))
+			declineFactor := 1.0 / float64(lobby.DrawingTime)
 			baseScore := int(maxBaseScore * math.Pow(1.0-declineFactor, float64(secondsLeft)))
 
 			//Every hint not shown, e.g. not needed, will give the player bonus points.


### PR DESCRIPTION
Note that the first two commits aren't actually part of the PR, as these changes are already on top of master. I just f'd up ;)

The score now slowly declines depending on how much time was taken.
This way, people that don't get the word fast enough, don't get punished too hard.
On top of the time factor, hints are now also taken into account. Each hint that
wasn't shown at the time of your guess, will award bonus points.

The drawer will now get the average score + an extra 10 points if everyone guessed the word correctly.