### PR TITLE
Fixes the size of the "clear canvas" button on the iPad. 

### DIFF
--- a/resources/frontend/lobby.css
+++ b/resources/frontend/lobby.css
@@ -243,6 +243,7 @@ input[type="button"]:active,
     height: 50px;
     width: 50px;
     border: 0;
+    padding: 0;
     background-color: rgb(218, 218, 218);
 }
 


### PR DESCRIPTION
Has no impact on other browsers...

Without the fix:
![image](https://user-images.githubusercontent.com/3397877/107875461-45472a00-6ec0-11eb-9f67-ae22750d06a6.png)
