### PR TITLE
Added info about the players name and the ability to directly change this for new users

### DIFF
--- a/resources/frontend/lobby.css
+++ b/resources/frontend/lobby.css
@@ -412,3 +412,8 @@ input[type="button"]:active,
     /* As this dialog is very important, it should always be on the top. */
     z-index: 100;
 }
+
+#own-name {
+    font-weight: bold;
+    margin-right: 1rem;
+}

--- a/templates/lobby.html
+++ b/templates/lobby.html
@@ -85,6 +85,11 @@
                             <div class="center-dialog-content">
                                 Please wait for your lobby host to start the game.
                             </div>
+                            <br/>
+                            <div class="center-dialog-content">
+                                Your name is: <span id="own-name"></span>
+                                <button class="dialog-button" onclick="showNameChangeDialog()">Change name</button>
+                            </div>
                         </div>
                     </div>
 
@@ -337,6 +342,7 @@
 
     const centerDialog = document.getElementById("center-dialog");
     const unstartedDialog = document.getElementById("unstarted-dialog");
+    const ownNameSpan = document.getElementById("own-name");
     const startDialog = document.getElementById("start-dialog");
     const gameOverDialog = document.getElementById("game-over-dialog");
     const gameOverDialogTitle = document.getElementById("game-over-dialog-title");
@@ -873,6 +879,7 @@
             //We simply abuse the player events to get our latest name, since there's no separate event for this.
             if (player.id === ownID) {
                 ownName = player.name;
+                ownNameSpan.innerHTML = ownName;
             }
 
             let stateStyleClass;


### PR DESCRIPTION
New users often had problems to see their actual name and to find the button change it.
So I added this to the dialog where the round hasn't started...