### PR TITLE
Renamed `ID` to `LobbyID` and `id` to `lobbyId` in `LobbyEntry`

### DIFF
--- a/communication/create.go
+++ b/communication/create.go
@@ -156,7 +156,7 @@ func ssrCreateLobby(w http.ResponseWriter, r *http.Request) {
 	//We only add the lobby if we could do all necessary pre-steps successfully.
 	state.AddLobby(lobby)
 
-	http.Redirect(w, r, CurrentBasePageConfig.RootPath+"/ssrEnterLobby?lobby_id="+lobby.ID, http.StatusFound)
+	http.Redirect(w, r, CurrentBasePageConfig.RootPath+"/ssrEnterLobby?lobby_id="+lobby.LobbyID, http.StatusFound)
 }
 
 func parsePlayerName(value string) (string, error) {

--- a/communication/lobby.go
+++ b/communication/lobby.go
@@ -142,7 +142,7 @@ func createLobbyData(lobby *game.Lobby) *LobbyData {
 		BasePageConfig:         CurrentBasePageConfig,
 		SettingBounds:          game.LobbySettingBounds,
 		EditableLobbySettings:  lobby.EditableLobbySettings,
-		LobbyID:                lobby.ID,
+		LobbyID:                lobby.LobbyID,
 		DrawingBoardBaseWidth:  game.DrawingBoardBaseWidth,
 		DrawingBoardBaseHeight: game.DrawingBoardBaseHeight,
 		MinBrushSize:           game.MinBrushSize,

--- a/communication/lobby_test.go
+++ b/communication/lobby_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCreateLobby(t *testing.T) {
 	data := createLobbyData(&game.Lobby{
-		ID: "TEST",
+		LobbyID: "TEST",
 	})
 
 	var previousSize uint8 = 0

--- a/communication/templates/lobby_create.html
+++ b/communication/templates/lobby_create.html
@@ -205,7 +205,7 @@
                             row.setAttribute("selected", "false");
                         })
                         newRow.setAttribute("selected", "true");
-                        selectedLobby = lobby.id;
+                        selectedLobby = lobby.lobbyId;
                         showLobbyDetails(lobby);
                     };
                     newRow.addEventListener("click", clickHandler, false);

--- a/communication/v1.go
+++ b/communication/v1.go
@@ -14,7 +14,7 @@ import (
 
 // LobbyEntry is an API object for representing a join-able public lobby.
 type LobbyEntry struct {
-	ID              string `json:"id"`
+	LobbyID         string `json:"lobbyId"`
 	PlayerCount     int    `json:"playerCount"`
 	MaxPlayers      int    `json:"maxPlayers"`
 	Round           int    `json:"round"`
@@ -31,7 +31,7 @@ func publicLobbies(w http.ResponseWriter, r *http.Request) {
 	lobbyEntries := make([]*LobbyEntry, 0, len(lobbies))
 	for _, lobby := range lobbies {
 		lobbyEntries = append(lobbyEntries, &LobbyEntry{
-			ID:              lobby.ID,
+			LobbyID:         lobby.LobbyID,
 			PlayerCount:     lobby.GetOccupiedPlayerSlots(),
 			MaxPlayers:      lobby.MaxPlayers,
 			Round:           lobby.Round,

--- a/game/data.go
+++ b/game/data.go
@@ -16,7 +16,7 @@ const slotReservationTime = time.Minute * 5
 // FIXME Field visibilities should be changed in case we ever serialize this.
 type Lobby struct {
 	// ID uniquely identified the Lobby.
-	ID string
+	LobbyID string
 
 	*EditableLobbySettings
 
@@ -271,7 +271,7 @@ func createLobby(
 	publicLobby bool) *Lobby {
 
 	lobby := &Lobby{
-		ID:          uuid.Must(uuid.NewV4()).String(),
+		LobbyID:     uuid.Must(uuid.NewV4()).String(),
 		DrawingTime: drawingTime,
 		MaxRounds:   rounds,
 		EditableLobbySettings: &EditableLobbySettings{

--- a/game/rocketchat.go
+++ b/game/rocketchat.go
@@ -75,7 +75,7 @@ func updateRocketChat(lobby *Lobby, player *Player) {
 	if count == 0 {
 		sendRocketChatMessage(fmt.Sprintf("%v has %v. The game has ended.", player.Name, action))
 	} else {
-		sendRocketChatMessage(fmt.Sprintf("%v has %v. There are %v players in the game. Join [here](%v%s/ssrEnterLobby?lobby_id=%v)", player.Name, action, count, scribbleURL, rootPath, lobby.ID))
+		sendRocketChatMessage(fmt.Sprintf("%v has %v. There are %v players in the game. Join [here](%v%s/ssrEnterLobby?lobby_id=%v)", player.Name, action, count, scribbleURL, rootPath, lobby.LobbyID))
 	}
 }
 

--- a/state/lobbies.go
+++ b/state/lobbies.go
@@ -54,7 +54,7 @@ func GetLobby(id string) *game.Lobby {
 	defer createDeleteMutex.Unlock()
 
 	for _, l := range lobbies {
-		if l.ID == id {
+		if l.LobbyID == id {
 			return l
 		}
 	}
@@ -100,7 +100,7 @@ func RemoveLobby(id string) {
 func removeLobby(id string) {
 	indexToDelete := -1
 	for index, l := range lobbies {
-		if l.ID == id {
+		if l.LobbyID == id {
 			indexToDelete = index
 			break
 		}
@@ -114,5 +114,5 @@ func removeLobby(id string) {
 func removeLobbyByIndex(indexToDelete int) {
 	lobby := lobbies[indexToDelete]
 	lobbies = append(lobbies[:indexToDelete], lobbies[indexToDelete+1:]...)
-	log.Printf("Closing lobby %s. There are currently %d open lobbies left.\n", lobby.ID, len(lobbies))
+	log.Printf("Closing lobby %s. There are currently %d open lobbies left.\n", lobby.LobbyID, len(lobbies))
 }


### PR DESCRIPTION
This pull request renames `ID` to `LobbyID` and `id` to `lobbyId` in `LobbyEntry`.