### PR TITLE
Mobile fullscreen support

### DIFF
--- a/communication/resources/base.css
+++ b/communication/resources/base.css
@@ -4,8 +4,11 @@ html, body {
 
 body {
     font-family: 'Montserrat';
-    background-color: antiquewhite;
     margin: 0;
+}
+
+body, body::backdrop, body:fullscreen {
+    background-color: antiquewhite;;
 }
 
 .content-wrapper {

--- a/communication/templates/lobby.html
+++ b/communication/templates/lobby.html
@@ -1367,6 +1367,19 @@
         }));
     }, false);
 
+    //Mobileclients often show the URL bar and the system bar, which takes
+    //way too much space away if the keyboard is also visible. This causes
+    //mobile clients to not be able to see the full drawing, which is annoying.
+    //Therefore we ask the browser to fullscreen the page.
+    const isMobile = navigator.userAgent.toLowerCase().indexOf("mobile") != -1;
+    applyMessage("system-message", "logger", navigator.userAgent.toLowerCase()+" contains mobile: " + isMobile);
+    if (isMobile) {
+        //If we try to request fullscreen directly, the request most likely gets denied.
+        //Therefore we try fullscreening whenever the user uses the message input.
+        messageInput.addEventListener("click", function() {
+            document.body.requestFullscreen();
+        });
+    }
 </script>
 </body>
 

--- a/game/lobby.go
+++ b/game/lobby.go
@@ -459,16 +459,15 @@ func handleNameChangeEvent(caller *Player, lobby *Lobby, name string) {
 
 	oldName := caller.Name
 	if newName == "" {
-		caller.Name = GeneratePlayerName()
-	} else {
-		caller.Name = newName
+		newName = GeneratePlayerName()
 	}
+	caller.Name = newName
 
 	log.Printf("%s is now %s\n", oldName, newName)
 
 	TriggerUpdateEvent("name-change", &NameChangeEvent{
 		PlayerID:   caller.ID,
-		PlayerName: caller.Name,
+		PlayerName: newName,
 	}, lobby)
 }
 


### PR DESCRIPTION
This almost works, however, the pointer coordinates seem to be wrong. I am unsure why this happens, but it doesn't only apply to the canvas, but all the elements.

As soon as that's fixed, a button to enter / exit fullscreen mode might be useful.
I am unsure whether it's the right thing to force fullscreen mode on messageInput tap, but I assume most users don't know that they can fullscreen websites at all.