### PR TITLE
add scribble.bixilon.de as public instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ The site will not display any ads or share any data with third parties.
 
 ## Play now
 
-Feel free to play on [scribblers.fly.dev](https://scribblers.fly.dev). Note
+There are some community hosted versions of the game (feel free to host your own instance and add it here!):
+ - [scribblers.fly.dev](https://scribblers.fly.dev) (Official instance, Note
 that the instance may not respond instantly, as it automatically shuts down
-if no traffic is received.
+if no traffic is received.)
+ - [scribble.bixilon.de](https://scribble.bixilon.de) (community instance maintained by @Bixilon)
+
 
 ## Configuration
 


### PR DESCRIPTION
I hope you endorse that I added a list of public available instances to the read me.

I still remember the original url (https://scribblers-official.herokuapp.com/) and sometimes it just shut down, people needed to reconnect and then I set up my own instance. I recently updated it to the latest version. No intentions to shut it down in near future, except if there is major abuse.



The server is hosted in munich, got enough resources and should be able to handle a couple of players. 