### PR TITLE
Reworking the game start flow

### DIFF
--- a/internal/frontend/resources/lobby.css
+++ b/internal/frontend/resources/lobby.css
@@ -1,3 +1,25 @@
+.ready-check-box-wrapper {
+    display: flex;
+    align-self: center;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+
+.ready-check-box {
+    padding: 0.5rem 1rem 0.5rem 1rem;
+    background-color: white;
+}
+
+.ready-check-box:has(input[type="checkbox"]:checked) {
+    background-color: rgb(255, 224, 66);
+}
+
+.ready-needed,
+.ready-count {
+    font-family: monospace;
+    font-size: 1rem;
+}
+
 #lobby-header {
     grid-column-start: 1;
     grid-column-end: 4;
@@ -500,11 +522,8 @@ input[type="button"]:active,
 
 .namechange-field {
     width: 100%;
+    height: 100%;
     box-sizing: border-box;
-}
-
-.namechange-apply-button {
-    margin-left: 0.5rem;
 }
 
 #waitchoose-drawer {

--- a/internal/frontend/resources/lobby.css
+++ b/internal/frontend/resources/lobby.css
@@ -3,12 +3,12 @@
     grid-column-end: 4;
     grid-row: 1;
 
-    display:grid;
+    display: grid;
     grid-template-columns: 15rem auto 18rem;
     grid-gap: 5px;
 }
 
-#lobby-header > * {
+#lobby-header>* {
     background-color: white;
     height: 100%;
     align-items: center;
@@ -22,7 +22,8 @@
     font-size: 0;
 }
 
-#round-container, #time-left {
+#round-container,
+#time-left {
     font-size: 1.5rem;
     align-self: center;
     display: flex;
@@ -57,7 +58,7 @@
     font-size: 1.5rem;
 }
 
-.guess-letter + .guess-letter {
+.guess-letter+.guess-letter {
     margin-left: 0.5rem;
 }
 
@@ -180,7 +181,7 @@
 
 .close-guess-message {
     font-weight: bold;
-    color:rgb(25, 166, 166);
+    color: rgb(25, 166, 166);
 }
 
 .message-input-form {
@@ -227,7 +228,7 @@
     margin-top: 1em;
 }
 
-.dialog-button + .dialog-button {
+.dialog-button+.dialog-button {
     margin-left: 0.25rem;
 }
 
@@ -256,8 +257,8 @@ input[type="button"]:active,
     width: 1.7rem;
     height: 1.7rem;
     /** Without these two, the button has too much height. */
-    display: inline-block; 
-    vertical-align: middle; 
+    display: inline-block;
+    vertical-align: middle;
 }
 
 .dot {
@@ -265,7 +266,7 @@ input[type="button"]:active,
     border-radius: 50%;
 }
 
-.line-width-button + .line-width-button-content {
+.line-width-button+.line-width-button-content {
     height: 50px;
     width: 50px;
     display: flex;
@@ -277,7 +278,7 @@ input[type="button"]:active,
     background-color: rgb(218, 218, 218);
 }
 
-.line-width-button:checked + .line-width-button-content {
+.line-width-button:checked+.line-width-button-content {
     background-color: rgb(243, 132, 247);
 }
 
@@ -303,7 +304,7 @@ input[type="button"]:active,
     background-color: rgb(218, 218, 218);
 }
 
-.canvas-button > img {
+.canvas-button>img {
     display: inline-block;
     vertical-align: middle;
 }
@@ -389,7 +390,7 @@ input[type="button"]:active,
     grid-template-rows: 1fr 1fr;
 }
 
-.player + .player {
+.player+.player {
     margin-top: 5px;
 }
 
@@ -406,6 +407,10 @@ input[type="button"]:active,
 
 .player-done {
     background-color: rgb(141, 224, 15);
+}
+
+.player-ready {
+    background-color: rgb(255, 224, 66);
 }
 
 .rank {
@@ -439,6 +444,7 @@ input[type="button"]:active,
 #kick-dialog-players {
     flex: 1;
 }
+
 .kick-player-button {
     width: 100%;
     border: none;
@@ -446,7 +452,7 @@ input[type="button"]:active,
     padding-bottom: 1rem;
 }
 
-.kick-player-button + .kick-player-button {
+.kick-player-button+.kick-player-button {
     margin-top: 0.5rem;
 }
 
@@ -458,7 +464,7 @@ input[type="button"]:active,
     background-color: rgb(245, 245, 245);
 }
 
-.gameover-scoreboard-entry + .gameover-scoreboard-entry {
+.gameover-scoreboard-entry+.gameover-scoreboard-entry {
     margin-top: 0.5rem;
 }
 
@@ -475,7 +481,7 @@ input[type="button"]:active,
 }
 
 .gameover-scoreboard-name {
-    flex:1;
+    flex: 1;
     text-align: center;
 }
 
@@ -505,28 +511,24 @@ input[type="button"]:active,
     font-weight: bold;
 }
 
-@media only screen
-  and (min-device-width: 375px)
-  and (max-device-width: 812px)
-  and (orientation: landscape)
-  and (display-mode: fullscreen) {
+@media only screen and (min-device-width: 375px) and (max-device-width: 812px) and (orientation: landscape) and (display-mode: fullscreen) {
     html {
         font-size: 0.8rem;
     }
+
     .dialog-title {
         font-size: 1.75rem;
     }
 }
 
-@media only screen
-and (min-device-width: 375px)
-and (max-device-width: 812px) {
+@media only screen and (min-device-width: 375px) and (max-device-width: 812px) {
     .dialog-title {
         font-size: 1.75rem;
     }
 }
 
-@media only screen and (orientation: portrait), (max-aspect-ratio: 4/3) {
+@media only screen and (orientation: portrait),
+(max-aspect-ratio: 4/3) {
     #lobby {
         grid-template-columns: 2fr 3fr;
         grid-template-rows: min-content min-content min-content auto;
@@ -540,14 +542,15 @@ and (max-device-width: 812px) {
         grid-row: 1;
     }
 
-    #round-container, #time-left {
+    #round-container,
+    #time-left {
         font-size: 1.2rem;
     }
 
     #time-left-value {
         min-width: 2.4rem;
         width: 2.4rem;
-    }    
+    }
 
     .header-button-image {
         width: 1.2rem;

--- a/internal/frontend/templates/lobby.html
+++ b/internal/frontend/templates/lobby.html
@@ -105,24 +105,23 @@
                         <div id="start-dialog" class="center-dialog">
                             <span class="dialog-title">{{.Translation.Get "start-the-game"}}</span>
                             <div class="center-dialog-content">
-                                <div style="display: flex; flex-direction: column;">
-                                    <div style="display: flex; flex-direction: row;
-                                    align-items: center;">
+                                <div style="display: flex; flex-direction:
+                                    column; gap: 0.5rem;">
+                                    <div style="display: flex; flex-direction:
+                                        row; gap: 0.5rem; align-items: center;">
                                         {{.Translation.Get "change-your-name"}}:
                                         <input class="namechange-field" type="text"
                                             id="namechange-field-start-dialog"></input>
-                                        <button class="dialog-button namechange-apply-button"
+                                        <button class="dialog-button"
                                             onclick="changeName(document.getElementById('namechange-field-start-dialog').value)">{{.Translation.Get "apply"}}</button>
                                     </div>
-                                    <div style="display: flex; flex-direction: row;
-                                    align-items: center;">
-                                        Ready&nbsp;<span id="ready-count">0</span>/<span id="ready-needed">0</span>
-                                    </div>
-                                    Once all players are ready, the game will start.
-                                    <div>
-                                        <span for="ready-state">Ready</span>
-                                        <input type="checkbox" name="ready-state" id="ready-state"
-                                            onchange="toggleReadiness()">
+                                    <div class="ready-check-box-wrapper">
+                                        <label class="ready-check-box" for="ready-state-start">
+                                            Ready
+                                            <input type="checkbox" name="ready-state-start" id="ready-state-start"
+                                                onchange="toggleReadiness()">
+                                            (<span class="ready-count">0</span>/<span class="ready-needed">0</span>)
+                                        </label>
                                     </div>
                                 </div>
                             </div>
@@ -196,8 +195,17 @@
                             <div class="center-dialog-content">
                                 <div id="game-over-scoreboard"></div>
                             </div>
+                            <div class="ready-check-box-wrapper">
+                                <label class="ready-check-box" for="ready-state-game-over">
+                                    Ready
+                                    <input type="checkbox" name="ready-state-game-over" id="ready-state-game-over"
+                                        onchange="toggleReadiness()">
+                                    (<span class="ready-count">0</span>/<span class="ready-needed">0</span>)
+                                </label>
+                            </div>
                             <div class="button-center-wrapper">
-                                <button id="restart-button" class="dialog-button" onclick="startGame()">Restart</button>
+                                <button id="restart-button" class="dialog-button" onclick="startGame()">{{.Translation.Get
+                                    "force-restart"}}</button>
                             </div>
                         </div>
 
@@ -1063,6 +1071,14 @@
                 } else if (parsed.type === "clear-drawing-board") {
                     clear(context);
                 } else if (parsed.type === "next-turn") {
+                    if (gameState === "ongoing") {
+                        //The previous turn has ended.
+                        showRoundEndMessage(parsed.data.previousWord);
+                    } else {
+                        //First turn, the game starts
+                        gameState = "ongoing";
+                    }
+
                     setRoundEndTime(parsed.data.roundEndTime);
 
                     //As soon as a turn starts, the round should be ongoing, so we make
@@ -1095,14 +1111,6 @@
 
                     allowDrawing = false;
                     updateCursor();
-
-                    if (gameState === "ongoing") {
-                        //The previous turn has ended.
-                        showRoundEndMessage(parsed.data.previousWord);
-                    } else {
-                        //First turn, the game starts
-                        gameState = "ongoing";
-                    }
                 } else if (parsed.type === "your-turn") {
                     playWav('{{.RootPath}}/resources/your-turn.wav?cache_bust={{.CacheBust}}');
                     //This dialog could potentially stay visible from last
@@ -1184,11 +1192,12 @@
         }
 
         function handleReadyEvent(ready) {
-            setRoundEndTime(ready.roundEndTime);
             ownerID = ready.ownerId;
+            ownID = ready.playerId;
+
+            setRoundEndTime(ready.roundEndTime);
             setUsernameLocally(ready.playerName);
             allowDrawing = ready.allowDrawing;
-            ownID = ready.playerId;
             round = ready.round;
             rounds = ready.rounds;
             gameState = ready.gameState;
@@ -1357,7 +1366,7 @@
         //applyPlayers takes the players passed, assigns them to cachedPlayers,
         //refreshes the scoreboard and updates the drawerID and drawerName variables.
         function applyPlayers(players) {
-            const matchOngoing = lobby.State === "ongoing";
+            const matchOngoing = gameState === "ongoing";
             if (!matchOngoing) {
                 let readyPlayers = 0;
                 let readyPlayersRequired = 0;
@@ -1371,10 +1380,22 @@
                     if (player.state === "ready") {
                         readyPlayers = readyPlayers + 1;
                     }
+
+                    if (player.id === ownID) {
+                        document.getElementById("ready-state-start").checked = player.state === "ready";
+                        document.getElementById("ready-state-game-over").checked = player.state === "ready";
+                    }
                 });
 
-                document.getElementById("ready-count").innerText = readyPlayers.toString();
-                document.getElementById("ready-needed").innerText = readyPlayersRequired.toString();
+                const readyCounts = document.getElementsByClassName("ready-count");
+                const reaadyNeededs = document.getElementsByClassName("ready-needed");
+
+                Array.from(readyCounts).forEach((element) => {
+                    element.innerText = readyPlayers.toString();
+                });
+                Array.from(reaadyNeededs).forEach((element) => {
+                    element.innerText = readyPlayersRequired.toString();
+                });
             }
 
             playerContainer.innerHTML = "";
@@ -1389,12 +1410,18 @@
 
                 playerDiv.classList.add("player");
 
+                const scoreAndStatusDiv = document.createElement("div");
+                scoreAndStatusDiv.classList.add("score-and-status");
+                playerDiv.appendChild(scoreAndStatusDiv);
+
+                const playerscoreDiv = document.createElement("div");
+                playerscoreDiv.classList.add("playerscore-group");
+                scoreAndStatusDiv.appendChild(playerscoreDiv);
+
                 if (matchOngoing) {
                     if (player.state === "standby") {
                         playerDiv.classList.add("player-done");
-                    }
-
-                    if (player.state === "drawing") {
+                    } else if (player.state === "drawing") {
                         drawerID = player.id;
                         drawerName = player.name;
 
@@ -1424,14 +1451,6 @@
                     playernameSpan.classList.add("playername-self");
                 }
                 playerDiv.appendChild(playernameSpan);
-
-                const scoreAndStatusDiv = document.createElement("div");
-                scoreAndStatusDiv.classList.add("score-and-status");
-                playerDiv.appendChild(scoreAndStatusDiv);
-
-                const playerscoreDiv = document.createElement("div");
-                playerscoreDiv.classList.add("playerscore-group");
-                scoreAndStatusDiv.appendChild(playerscoreDiv);
 
                 const playerscoreSpan = document.createElement("span");
                 playerscoreSpan.classList.add("playerscore");

--- a/internal/frontend/templates/lobby.html
+++ b/internal/frontend/templates/lobby.html
@@ -106,34 +106,29 @@
                             <span class="dialog-title">{{.Translation.Get "start-the-game"}}</span>
                             <div class="center-dialog-content">
                                 <div style="display: flex; flex-direction: column;">
-                                    {{.Translation.Get "change-your-name"}}:
-                                    <div style="display: flex; flex-direction: row;">
+                                    <div style="display: flex; flex-direction: row;
+                                    align-items: center;">
+                                        {{.Translation.Get "change-your-name"}}:
                                         <input class="namechange-field" type="text"
                                             id="namechange-field-start-dialog"></input>
                                         <button class="dialog-button namechange-apply-button"
                                             onclick="changeName(document.getElementById('namechange-field-start-dialog').value)">{{.Translation.Get "apply"}}</button>
                                     </div>
+                                    <div style="display: flex; flex-direction: row;
+                                    align-items: center;">
+                                        Ready&nbsp;<span id="ready-count">0</span>/<span id="ready-needed">0</span>
+                                    </div>
+                                    Once all players are ready, the game will start.
+                                    <div>
+                                        <span for="ready-state">Ready</span>
+                                        <input type="checkbox" name="ready-state" id="ready-state"
+                                            onchange="toggleReadiness()">
+                                    </div>
                                 </div>
                             </div>
                             <div class="button-center-wrapper">
-                                <button class="dialog-button"
-                                    onclick="startGame()">{{.Translation.Get "start"}}</button>
-                            </div>
-                        </div>
-
-                        <div id="unstarted-dialog" class="center-dialog">
-                            <span class="dialog-title">{{.Translation.Get "game-not-started-title"}}</span>
-                            <div class="center-dialog-content">
-                                <div style="display: flex; flex-direction: column;">
-                                    <p>{{.Translation.Get "waiting-for-host-to-start"}}</p>
-                                    {{.Translation.Get "change-your-name"}}:
-                                    <div style="display: flex; flex-direction: row;">
-                                        <input class="namechange-field" type="text"
-                                            id="namechange-field-unstarted-dialog"></input>
-                                        <button class="dialog-button namechange-apply-button"
-                                            onclick="changeName(document.getElementById('namechange-field-unstarted-dialog').value)">{{.Translation.Get "apply"}}</button>
-                                    </div>
-                                </div>
+                                <button id="force-start-button" class="dialog-button"
+                                    onclick="startGame()">{{.Translation.Get "force-start"}}</button>
                             </div>
                         </div>
 
@@ -475,7 +470,7 @@
         //players could be killed and even cause the lobby being closed. Since
         //that's very frustrating, we want to avoid that.
         window.setInterval(() => {
-            socket.send(JSON.stringify({ type: "keep-alive" }));
+            socket.send(JSON.stringify({type: "keep-alive"}));
         }, 5000);
 
         //Makes sure that the server notices that the player disconnects.
@@ -501,11 +496,9 @@
 
         const centerDialogs = document.getElementById("center-dialogs");
 
-        const unstartedDialog = document.getElementById("unstarted-dialog");
         const waitChooseDialog = document.getElementById("waitchoose-dialog");
         const waitChooseDrawerSpan = document.getElementById("waitchoose-drawer");
         const namechangeDialog = document.getElementById("namechange-dialog");
-        const namechangeFieldUnstartedDialog = document.getElementById("namechange-field-unstarted-dialog");
         const namechangeFieldStartDialog = document.getElementById("namechange-field-start-dialog");
         const namechangeField = document.getElementById("namechange-field");
 
@@ -514,6 +507,7 @@
         const lobbySettingsDialog = document.getElementById("lobbysettings-dialog");
 
         const startDialog = document.getElementById("start-dialog");
+        const forceStartButton = document.getElementById("force-start-button");
         const gameOverDialog = document.getElementById("game-over-dialog");
         const gameOverDialogTitle = document.getElementById("game-over-dialog-title");
         const gameOverScoreboard = document.getElementById("game-over-scoreboard");
@@ -652,7 +646,6 @@
 
         function setUsernameLocally(name) {
             ownName = name;
-            namechangeFieldUnstartedDialog.value = name;
             namechangeFieldStartDialog.value = name;
             namechangeField.value = name;
         }
@@ -714,8 +707,8 @@
         //The drawing board has a base size. This base size results in a certain ratio
         //that the actual canvas has to be resized accordingly too. This is needed
         //since not every client has the same screensize.
-        const baseWidth = {{.DrawingBoardBaseWidth }};
-        const baseHeight = {{.DrawingBoardBaseHeight }};
+        const baseWidth = {{.DrawingBoardBaseWidth}};
+        const baseHeight = {{.DrawingBoardBaseHeight}};
         const boardRatio = baseWidth / baseHeight;
 
         // Moving this here to extract the context after resizing
@@ -830,7 +823,7 @@
         function hexStringToRgbColorObject(hexString) {
             const hexColorsRegex = /#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})/i;
             const match = hexString.match(hexColorsRegex)
-            return { r: parseInt(match[1], 16), g: parseInt(match[2], 16), b: parseInt(match[3], 16) };
+            return {r: parseInt(match[1], 16), g: parseInt(match[2], 16), b: parseInt(match[3], 16)};
         }
 
         function rgbColorObjectToHexString(color) {
@@ -844,7 +837,7 @@
             return Number(number).toString(16).padStart(2, "0");
         }
 
-        const rubberColor = { r: 255, g: 255, b: 255 };
+        const rubberColor = {r: 255, g: 255, b: 255};
 
         function updateCursor() {
             if (allowDrawing) {
@@ -891,10 +884,10 @@
             );
 
             if (hsp > 127.5) {
-                return { r: 0, g: 0, b: 0 };
+                return {r: 0, g: 0, b: 0};
             }
 
-            return { r: 255, g: 255, b: 255 };
+            return {r: 255, g: 255, b: 255};
         }
 
         function setCircleCursor(innerColor, size) {
@@ -913,6 +906,12 @@
             const innerColorCSS = "rgb(" + innerColor.r + "," + innerColor.g + "," + innerColor.b + ")";
             const outerColorCSS = "rgb(" + outerColor.r + "," + outerColor.g + "," + outerColor.b + ")";
             return `<circle cx="` + circleRadius + `" cy="` + circleRadius + `" r="` + circleRadius + `" style="fill: ` + innerColorCSS + `; stroke: ` + outerColorCSS + `;"/>`;
+        }
+
+        function toggleReadiness() {
+            socket.send(JSON.stringify({
+                type: "toggle-readiness",
+            }));
         }
 
         function startGame() {
@@ -1069,7 +1068,6 @@
                     //As soon as a turn starts, the round should be ongoing, so we make
                     //sure that all types of dialogs, that indicate the game isn't
                     //ongoing, are not visible anymore.
-                    unstartedDialog.style.visibility = "hidden";
                     startDialog.style.visibility = "hidden";
                     restartButton.style.display = "none";
                     gameOverDialog.style.visibility = "hidden";
@@ -1210,10 +1208,11 @@
             updateCursor();
 
             if (ready.gameState === "unstarted") {
+                startDialog.style.visibility = "visible";
                 if (ownerID === ownID) {
-                    startDialog.style.visibility = "visible";
+                    forceStartButton.style.display = "block";
                 } else {
-                    unstartedDialog.style.visibility = "visible";
+                    forceStartButton.style.display = "none";
                 }
             } else if (ready.gameState === "gameOver") {
                 gameOverDialog.style.visibility = "visible";
@@ -1358,6 +1357,26 @@
         //applyPlayers takes the players passed, assigns them to cachedPlayers,
         //refreshes the scoreboard and updates the drawerID and drawerName variables.
         function applyPlayers(players) {
+            const matchOngoing = lobby.State === "ongoing";
+            if (!matchOngoing) {
+                let readyPlayers = 0;
+                let readyPlayersRequired = 0;
+
+                players.forEach(player => {
+                    if (!player.connected) {
+                        return;
+                    }
+
+                    readyPlayersRequired = readyPlayersRequired + 1;
+                    if (player.state === "ready") {
+                        readyPlayers = readyPlayers + 1;
+                    }
+                });
+
+                document.getElementById("ready-count").innerText = readyPlayers.toString();
+                document.getElementById("ready-needed").innerText = readyPlayersRequired.toString();
+            }
+
             playerContainer.innerHTML = "";
             cachedPlayers = players;
             players.forEach(player => {
@@ -1369,8 +1388,27 @@
                 const playerDiv = document.createElement("div");
 
                 playerDiv.classList.add("player");
-                if (player.state === "standby") {
-                    playerDiv.classList.add("player-done");
+
+                if (matchOngoing) {
+                    if (player.state === "standby") {
+                        playerDiv.classList.add("player-done");
+                    }
+
+                    if (player.state === "drawing") {
+                        drawerID = player.id;
+                        drawerName = player.name;
+
+                        const playerStateImage = createPlayerStateImageNode("{{.RootPath}}/resources/pencil.svg?cache_bust={{.CacheBust}}");
+                        playerStateImage.style.transform = "scaleX(-1)";
+                        scoreAndStatusDiv.appendChild(playerStateImage);
+                    } else if (player.state === "standby") {
+                        const playerStateImage = createPlayerStateImageNode("{{.RootPath}}/resources/checkmark.svg?cache_bust={{.CacheBust}}");
+                        scoreAndStatusDiv.appendChild(playerStateImage);
+                    }
+                } else {
+                    if (player.state === "ready") {
+                        playerDiv.classList.add("player-ready");
+                    }
                 }
 
                 const rankSpan = document.createElement("span");
@@ -1404,19 +1442,6 @@
                 lastPlayerscoreSpan.classList.add("last-turn-score");
                 lastPlayerscoreSpan.innerText = '{{.Translation.Get "last-turn"}}'.format(player.lastScore);
                 playerscoreDiv.appendChild(lastPlayerscoreSpan);
-
-
-                if (player.state === "drawing") {
-                    drawerID = player.id;
-                    drawerName = player.name;
-
-                    const playerStateImage = createPlayerStateImageNode("{{.RootPath}}/resources/pencil.svg?cache_bust={{.CacheBust}}");
-                    playerStateImage.style.transform = "scaleX(-1)";
-                    scoreAndStatusDiv.appendChild(playerStateImage);
-                } else if (player.state === "standby") {
-                    const playerStateImage = createPlayerStateImageNode("{{.RootPath}}/resources/checkmark.svg?cache_bust={{.CacheBust}}");
-                    scoreAndStatusDiv.appendChild(playerStateImage);
-                }
 
                 playerContainer.appendChild(playerDiv);
             });

--- a/internal/game/data.go
+++ b/internal/game/data.go
@@ -140,6 +140,7 @@ const (
 	Guessing PlayerState = "guessing"
 	Drawing  PlayerState = "drawing"
 	Standby  PlayerState = "standby"
+	Ready    PlayerState = "ready"
 )
 
 // GetPlayer searches for a player, identifying them by usersession.
@@ -179,7 +180,6 @@ func createPlayer(name string) *Player {
 		userSession:  uuid.Must(uuid.NewV4()),
 		votedForKick: make(map[uuid.UUID]bool),
 		socketMutex:  &sync.Mutex{},
-		State:        Guessing,
 	}
 }
 

--- a/internal/game/lobby.go
+++ b/internal/game/lobby.go
@@ -187,7 +187,7 @@ func (lobby *Lobby) HandleEvent(eventType string, payload []byte, player *Player
 		handleKickVoteEvent(lobby, player, toKickID)
 	} else if eventType == EventTypeToggleReadiness {
 		if lobby.State != Ongoing {
-			if player.State == Standby {
+			if player.State != Ready {
 				player.State = Ready
 			} else {
 				player.State = Standby
@@ -195,7 +195,7 @@ func (lobby *Lobby) HandleEvent(eventType string, payload []byte, player *Player
 
 			allPlayersReady := true
 			for _, otherPlayer := range lobby.players {
-				if otherPlayer.State == Standby {
+				if otherPlayer.State != Ready {
 					allPlayersReady = false
 					break
 				}
@@ -1037,6 +1037,11 @@ func (lobby *Lobby) OnPlayerDisconnect(player *Player) {
 
 	player.disconnectTime = &disconnectTime
 	lobby.LastPlayerDisconnectTime = &disconnectTime
+
+	// Reset from potentially ready to standby
+	if lobby.State != Ongoing {
+		player.State = Standby
+	}
 
 	recalculateRanks(lobby)
 	lobby.Broadcast(&Event{Type: EventTypeUpdatePlayers, Data: lobby.players})

--- a/internal/game/shared.go
+++ b/internal/game/shared.go
@@ -19,10 +19,11 @@ import (
 
 // Eevnts that are just incomming from the client.
 const (
-	EventTypeStart          = "start"
-	EventTypeRequestDrawing = "request-drawing"
-	EventTypeChooseWord     = "choose-word"
-	EventTypeUndo           = "undo"
+	EventTypeStart           = "start"
+	EventTypeToggleReadiness = "toggle-readiness"
+	EventTypeRequestDrawing  = "request-drawing"
+	EventTypeChooseWord      = "choose-word"
+	EventTypeUndo            = "undo"
 )
 
 // Events that are outgoing only.
@@ -148,7 +149,7 @@ type NameChangeEvent struct {
 // is usually part of the "next-turn" event, which we don't send, since the
 // game is over already.
 type GameOverEvent struct {
-	*Ready
+	*ReadyEvent
 	PreviousWord string `json:"previousWord"`
 }
 
@@ -175,10 +176,10 @@ type OutgoingMessage struct {
 	AuthorID uuid.UUID `json:"authorId"`
 }
 
-// Ready represents the initial state that a user needs upon connection.
+// ReadyEvent represents the initial state that a user needs upon connection.
 // This includes all the necessary things for properly running a client
 // without receiving any more data.
-type Ready struct {
+type ReadyEvent struct {
 	WordHints          []*WordHint `json:"wordHints"`
 	PlayerName         string      `json:"playerName"`
 	Players            []*Player   `json:"players"`

--- a/internal/game/shared_easyjson.go
+++ b/internal/game/shared_easyjson.go
@@ -156,7 +156,7 @@ func (v *StringDataEvent) UnmarshalJSON(data []byte) error {
 func (v *StringDataEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson9aa6bd57DecodeGithubComScribbleRsScribbleRsInternalGame1(l, v)
 }
-func easyjson9aa6bd57DecodeGithubComScribbleRsScribbleRsInternalGame2(in *jlexer.Lexer, out *Ready) {
+func easyjson9aa6bd57DecodeGithubComScribbleRsScribbleRsInternalGame2(in *jlexer.Lexer, out *ReadyEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -298,7 +298,7 @@ func easyjson9aa6bd57DecodeGithubComScribbleRsScribbleRsInternalGame2(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjson9aa6bd57EncodeGithubComScribbleRsScribbleRsInternalGame2(out *jwriter.Writer, in Ready) {
+func easyjson9aa6bd57EncodeGithubComScribbleRsScribbleRsInternalGame2(out *jwriter.Writer, in ReadyEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -413,26 +413,26 @@ func easyjson9aa6bd57EncodeGithubComScribbleRsScribbleRsInternalGame2(out *jwrit
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v Ready) MarshalJSON() ([]byte, error) {
+func (v ReadyEvent) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson9aa6bd57EncodeGithubComScribbleRsScribbleRsInternalGame2(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Ready) MarshalEasyJSON(w *jwriter.Writer) {
+func (v ReadyEvent) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson9aa6bd57EncodeGithubComScribbleRsScribbleRsInternalGame2(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
-func (v *Ready) UnmarshalJSON(data []byte) error {
+func (v *ReadyEvent) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
 	easyjson9aa6bd57DecodeGithubComScribbleRsScribbleRsInternalGame2(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Ready) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *ReadyEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson9aa6bd57DecodeGithubComScribbleRsScribbleRsInternalGame2(l, v)
 }
 func easyjson9aa6bd57DecodeGithubComScribbleRsScribbleRsInternalGame3(in *jlexer.Lexer, out *RGBColor) {
@@ -1316,7 +1316,7 @@ func easyjson9aa6bd57DecodeGithubComScribbleRsScribbleRsInternalGame12(in *jlexe
 		in.Skip()
 		return
 	}
-	out.Ready = new(Ready)
+	out.ReadyEvent = new(ReadyEvent)
 	in.Delim('{')
 	for !in.IsDelim('}') {
 		key := in.UnsafeFieldName(false)

--- a/internal/translations/de_DE.go
+++ b/internal/translations/de_DE.go
@@ -5,8 +5,9 @@ func initGermanTranslation() {
 
 	translation.put("requires-js", "Diese Website benötigt JavaScript um korrekt zu funktionieren.")
 
-	translation.put("start-the-game", "Starte das Spiel")
+	translation.put("start-the-game", "Mach dich bereit!")
 	translation.put("force-start", "Start erzwingen")
+	translation.put("force-restart", "Neustart erzwingen")
 	translation.put("game-not-started-title", "Warte auf Spielstart")
 	translation.put("waiting-for-host-to-start", "Bitte warte bis der Lobby Besitzer das Spiel startet.")
 

--- a/internal/translations/de_DE.go
+++ b/internal/translations/de_DE.go
@@ -6,7 +6,7 @@ func initGermanTranslation() {
 	translation.put("requires-js", "Diese Website benötigt JavaScript um korrekt zu funktionieren.")
 
 	translation.put("start-the-game", "Starte das Spiel")
-	translation.put("start", "Starten")
+	translation.put("force-start", "Start erzwingen")
 	translation.put("game-not-started-title", "Warte auf Spielstart")
 	translation.put("waiting-for-host-to-start", "Bitte warte bis der Lobby Besitzer das Spiel startet.")
 
@@ -14,7 +14,7 @@ func initGermanTranslation() {
 
 	translation.put("round", "Runde")
 	translation.put("toggle-soundeffects", "Sound ein- / ausschalten")
-	translation.put("change-your-name", "Benutzernamen editieren")
+	translation.put("change-your-name", "Benutzername")
 	translation.put("randomize", "Zufälliger Name")
 	translation.put("apply", "Anwenden")
 	translation.put("save", "Speichern")

--- a/internal/translations/en_us.go
+++ b/internal/translations/en_us.go
@@ -5,8 +5,9 @@ func initEnglishTranslation() Translation {
 
 	translation.put("requires-js", "This website requires JavaScript to run properly.")
 
-	translation.put("start-the-game", "Start the game")
+	translation.put("start-the-game", "Ready up!")
 	translation.put("force-start", "Force Start")
+	translation.put("force-restart", "Force Restart")
 	translation.put("game-not-started-title", "Game hasn't started")
 	translation.put("waiting-for-host-to-start", "Please wait for your lobby host to start the game.")
 

--- a/internal/translations/en_us.go
+++ b/internal/translations/en_us.go
@@ -6,13 +6,13 @@ func initEnglishTranslation() Translation {
 	translation.put("requires-js", "This website requires JavaScript to run properly.")
 
 	translation.put("start-the-game", "Start the game")
-	translation.put("start", "Start")
+	translation.put("force-start", "Force Start")
 	translation.put("game-not-started-title", "Game hasn't started")
 	translation.put("waiting-for-host-to-start", "Please wait for your lobby host to start the game.")
 
 	translation.put("round", "Round")
 	translation.put("toggle-soundeffects", "Toggle soundeffects")
-	translation.put("change-your-name", "Edit your username")
+	translation.put("change-your-name", "Username")
 	translation.put("randomize", "Randomize")
 	translation.put("apply", "Apply")
 	translation.put("save", "Save")


### PR DESCRIPTION
Currently the game needs to be started by the owner. This has some downsides.

Related issues are:

#187 #207 #194 

The goal is to introduce a voting system, while preserving the ability for the owner to force-start.

Expected for a functional implementation:

- [x] Display ready state (x out of y players are ready)
- [x] Start once all required players are ready
- [x] Allow force starting any time
- [x] Apply voting systems on restarts as well (Prevent duping the HTML if easily possible)
- [x] Take into account disconnecting an reconnecting; Disconnecting should reset ready state
- [x] Make it not look like 💩 

Things to consider:

- [ ] AFK system / Spectator system; Afk players could be moved into spectator mode until they come back
  > It should be decided how agressive a player is determined AFK. We could do this the chill way, which would be client side "window.onblur" for "tabbed out" or server side "no events received since" (Except for the keep-alive)
  > *Alternatively, players can still be kicked if they do not ready, so maybe it is not too bad*
  >
  > OR once enough players are ready, a timer starts to start the game. Kinda like risk of rain, but less agressive