### PR TITLE
docker: don't run executable as root

### DIFF
--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -36,3 +36,5 @@ COPY --from=builder /app/scribblers /scribblers
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/scribblers"]
+
+USER 248:248

--- a/linux.Dockerfile
+++ b/linux.Dockerfile
@@ -33,3 +33,5 @@ COPY --from=builder /app/scribblers /scribblers
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/scribblers"]
+
+USER 248:248


### PR DESCRIPTION
It runs them as user and group 248, just a random numer that I mostly use for my docker users.