### PR TITLE
fix: panic on error page load (introduced after adding RTL support)

### DIFF
--- a/internal/frontend/http.go
+++ b/internal/frontend/http.go
@@ -167,10 +167,11 @@ type errorPageData struct {
 }
 
 // userFacingError will return the occurred error as a custom html page to the caller.
-func (handler *SSRHandler) userFacingError(w http.ResponseWriter, errorMessage string) {
+func (handler *SSRHandler) userFacingError(w http.ResponseWriter, errorMessage string, translation *translations.Translation) {
 	err := pageTemplates.ExecuteTemplate(w, "error-page", &errorPageData{
 		BasePageConfig: handler.basePageConfig,
 		ErrorMessage:   errorMessage,
+		Translation:    translation,
 	})
 	// This should never happen, but if it does, something is very wrong.
 	if err != nil {

--- a/internal/frontend/index.go
+++ b/internal/frontend/index.go
@@ -276,7 +276,7 @@ func (handler *SSRHandler) ssrCreateLobby(writer http.ResponseWriter, request *h
 	if err != nil {
 		pageData.Errors = append(pageData.Errors, err.Error())
 		if err := pageTemplates.ExecuteTemplate(writer, "index", pageData); err != nil {
-			handler.userFacingError(writer, err.Error())
+			handler.userFacingError(writer, err.Error(), translation)
 		}
 
 		return

--- a/internal/frontend/lobby.go
+++ b/internal/frontend/lobby.go
@@ -55,7 +55,7 @@ func (handler *SSRHandler) lobbyJs(writer http.ResponseWriter, request *http.Req
 func (handler *SSRHandler) ssrEnterLobby(writer http.ResponseWriter, request *http.Request) {
 	lobby := state.GetLobby(request.PathValue("lobby_id"))
 	if lobby == nil {
-		handler.userFacingError(writer, api.ErrLobbyNotExistent.Error())
+		handler.userFacingError(writer, api.ErrLobbyNotExistent.Error(), nil)
 		return
 	}
 
@@ -93,12 +93,12 @@ func (handler *SSRHandler) ssrEnterLobbyNoChecks(
 
 		if player == nil {
 			if !lobby.HasFreePlayerSlot() {
-				handler.userFacingError(writer, "Sorry, but the lobby is full.")
+				handler.userFacingError(writer, "Sorry, but the lobby is full.", translation)
 				return
 			}
 
 			if !lobby.CanIPConnect(requestAddress) {
-				handler.userFacingError(writer, "Sorry, but you have exceeded the maximum number of clients per IP.")
+				handler.userFacingError(writer, "Sorry, but you have exceeded the maximum number of clients per IP.", translation)
 				return
 			}
 
@@ -107,7 +107,7 @@ func (handler *SSRHandler) ssrEnterLobbyNoChecks(
 			api.SetGameplayCookies(writer, request, newPlayer, lobby)
 		} else {
 			if player.Connected && player.GetWebsocket() != nil {
-				handler.userFacingError(writer, "It appears you already have an open tab for this lobby.")
+				handler.userFacingError(writer, "It appears you already have an open tab for this lobby.", translation)
 				return
 			}
 			player.SetLastKnownAddress(requestAddress)

--- a/internal/frontend/templates/error.html
+++ b/internal/frontend/templates/error.html
@@ -11,7 +11,7 @@
     {{template "favicon-decl" .}}
 </head>
 
-<body {{if eq .Translation.IsRtl true}} dir="rtl" {{end}}>
+<body {{if and (ne .Translation nil) (eq .Translation.IsRtl true)}} dir="rtl" {{end}}>
     <div id="app">
         <div class="error-pane-wrapper">
             <div class="error-pane">

--- a/internal/frontend/templates/footer.html
+++ b/internal/frontend/templates/footer.html
@@ -8,6 +8,7 @@
 <a class="footer-item" href="https://github.com/scribble-rs/scribble.rs/releases/tag/{{.Version}}"
     target="_blank">{{.Version}}</a>
 {{end}}
+{{if ne .Translation nil}}
 <a class="footer-item" href="https://github.com/scribble-rs/scribble.rs"
     target="_blank">{{.Translation.Get "source-code"}}</a>
 <a class="footer-item" href="https://github.com/scribble-rs/scribble.rs/wiki"
@@ -15,4 +16,5 @@
 <a class="footer-item" href="https://github.com/scribble-rs/scribble.rs/issues/new"
     target="_blank">{{.Translation.Get "submit-feedback"}}</a>
 <a class="footer-item" href="{{.RootPath}}/v1/stats" target="_blank">{{.Translation.Get "stats"}}</a>
+{{end}}
 {{end}}


### PR DESCRIPTION
Hot-fixing panic introduced by #388  as in some flows the `Translation` struct was not instantiated or not passed to `userFacingError`.

This hot fix fixes the panic but as of now it prevents translation of some strings (which are currently hardcoded in English anyway). I may improve this in a future PR.