### PR TITLE
fix: word hints chat message in RTL languages and missing white-spaces

### DIFF
--- a/internal/frontend/lobby.js
+++ b/internal/frontend/lobby.js
@@ -999,19 +999,21 @@ const handleEvent = (parsed) => {
 
         // We don't do this in applyWordHints because that's called in all kinds of places
         if (parsed.data.some((hint) => hint.character)) {
-            appendMessage(
-                "system-message",
-                '{{.Translation.Get "system"}}',
-                `{{.Translation.Get "word-hint-revealed"}}`.format(
-                    parsed.data
-                        .map((hint) =>
-                            hint.character && hint.revealed
-                                ? String.fromCharCode(hint.character)
-                                : "_",
-                        )
-                        .join(" "),
-                ),
-            );
+          var hints = parsed.data.map((hint) => {
+              if (hint.character) {
+                  var char = String.fromCharCode(hint.character);
+                  if (char === " " || hint.revealed) {
+                      return char;
+                  }
+              }
+              return "_";
+          }).join(" ");
+          appendMessage(
+              ["system-message", "hint-chat-message"],
+              '{{.Translation.Get "system"}}',
+              '{{.Translation.Get "word-hint-revealed"}}\n' + hints,
+              { "dir": wordContainer.getAttribute("dir") },
+          );
         }
     } else if (parsed.type === "message") {
         appendMessage(null, parsed.data.author, parsed.data.content);
@@ -1399,15 +1401,19 @@ window.setInterval(() => {
 //appendMessage adds a new message to the message container. If the
 //message amount is too high, we cut off a part of the messages to
 //prevent lagging and useless memory usage.
-function appendMessage(styleClass, author, message) {
+function appendMessage(styleClass, author, message, attrs) {
     if (messageContainer.childElementCount >= 100) {
         messageContainer.removeChild(messageContainer.firstChild);
     }
 
     const newMessageDiv = document.createElement("div");
     newMessageDiv.classList.add("message");
-    if (styleClass !== null && styleClass !== "") {
-        newMessageDiv.classList.add(styleClass);
+    if (isString(styleClass)) {
+      styleClass = [styleClass];
+    }
+
+    for (const cls of styleClass){
+      newMessageDiv.classList.add(cls);
     }
 
     if (author !== null && author !== "") {
@@ -1421,6 +1427,14 @@ function appendMessage(styleClass, author, message) {
     messageSpan.classList.add("message-content");
     messageSpan.innerText = message;
     newMessageDiv.appendChild(messageSpan);
+
+    if (attrs !== null && attrs !== "") {
+      if (isObject(attrs)) {
+        for (const [attrKey, attrValue] of Object.entries(attrs)) {
+          messageSpan.setAttribute(attrKey, attrValue);
+        }
+      }
+    }
 
     messageContainer.appendChild(newMessageDiv);
 }
@@ -2010,6 +2024,17 @@ function getCookie(name) {
         cookie[split[0].trim()] = split.slice(1).join("=");
     });
     return cookie[name];
+}
+
+function isString(obj) {
+  return typeof obj === 'string';
+}
+
+function isObject(obj) {
+  return typeof obj === 'object' &&
+    obj !== null &&
+    !Array.isArray(obj) &&
+    Object.prototype.toString.call(obj) === '[object Object]';
 }
 
 const connectToWebsocket = () => {

--- a/internal/frontend/resources/lobby.css
+++ b/internal/frontend/resources/lobby.css
@@ -160,6 +160,11 @@ kbd {
     overflow-x: hidden;
 }
 
+.hint-chat-message {
+    white-space: pre;
+    text-wrap-mode: wrap;
+}
+
 .hint-underline {
     border-bottom: 0.2rem black solid;
     padding-bottom: 0.1rem;

--- a/internal/translations/en_us.go
+++ b/internal/translations/en_us.go
@@ -99,7 +99,7 @@ func initEnglishTranslation() *Translation {
 	translation.put("game-over", "You placed %s. with %s points")
 	translation.put("drawer-disconnected", "Turn ended early, drawer disconnected.")
 	translation.put("guessers-disconnected", "Turn ended early, guessers disconnected.")
-	translation.put("word-hint-revealed", "A word hint was revealed!\nHints: %s")
+	translation.put("word-hint-revealed", "A word hint was revealed!")
 
 	translation.put("change-active-color", "Change your active color")
 	translation.put("use-pencil", "Use pencil")

--- a/internal/translations/he.go
+++ b/internal/translations/he.go
@@ -100,6 +100,7 @@ func initHebrewTranslation() {
 	translation.put("game-over", "סיימת במקום ה %s עם %s נקודות")
 	translation.put("drawer-disconnected", "התור הסתיים, השחקן שצייר התנתק")
 	translation.put("guessers-disconnected", "התור הסתיים, כל השחקנים המנחשים התנתקו")
+	translation.put("word-hint-revealed", "נחשף רמז")
 
 	translation.put("change-active-color", "שינוי צבע")
 	translation.put("use-pencil", "עיפרון")


### PR DESCRIPTION
Closes #402

This fixes:

- Word hints in chat messages to appear correctly in RTL wordpacks
- Word hints in chat messages now appear correctly for words with white spaces (before they appeared as a single word, regardless of RTL due to how white spaces are handled by default)

I modified the English translation of `word-hint-revealed` as it felt a bit redundant, plus the extra ":" was a bit tough to be handled properly for RTL wordpacks without introducing a separate DOM element.  

Before

<img width="991" height="141" alt="image" src="https://github.com/user-attachments/assets/6a549cd1-bcc4-4e82-99de-83446c7dae2c" />

<hr>

After

<img width="991" height="141" alt="image" src="https://github.com/user-attachments/assets/8ba4d4c7-1436-4fc1-9d9e-5ec218eb4e23" />
